### PR TITLE
Alternative Field Encoding for Types

### DIFF
--- a/src/nistDecode.ts
+++ b/src/nistDecode.ts
@@ -26,6 +26,7 @@ import {
   SEPARATOR_UNIT,
 } from './nistUtils';
 import { nistValidation } from './nistValidation';
+import { getPerTotOptions } from './nistVisitor';
 import { failure, Result, success } from './result';
 
 /** Decoding options for a single NIST Field. */
@@ -38,6 +39,7 @@ export interface NistFieldDecodeOptions extends NistFieldCodecOptions {
    * This behaviour can be overridden on a per-field basis by passing a custom parser property.
    */
   parser?: (field: NistField, nist: NistFile) => Result<NistFieldValue, NistParseError>;
+  informationDecoder?: (buffer: Buffer, startOffset: number, endOffset: number) => string;
 }
 
 /** Decoding options for one NIST record. */
@@ -130,7 +132,9 @@ const decodeNistSubfield = (
   buffer: Buffer,
   startOffset: number,
   endOffset: number,
+  options?: NistFieldDecodeOptions,
 ): NistSubfield => {
+  const decoder = options?.informationDecoder || stringValue;
   let offset = startOffset;
 
   let unitSeparator = findSeparator(buffer, SEPARATOR_UNIT, offset, endOffset);
@@ -139,7 +143,7 @@ const decodeNistSubfield = (
     while (offset <= endOffset) {
       subfield = [
         ...subfield,
-        stringValue(buffer, offset, unitSeparator ? unitSeparator - 1 : endOffset),
+        decoder(buffer, offset, unitSeparator ? unitSeparator - 1 : endOffset),
       ];
       offset = (unitSeparator || endOffset) + 1;
       unitSeparator = findSeparator(buffer, SEPARATOR_UNIT, offset, endOffset);
@@ -149,9 +153,9 @@ const decodeNistSubfield = (
 
   // The same logic is present also in decodeNistFieldValue.
   if (alwaysDecodeAsSet(key)) {
-    return [stringValue(buffer, startOffset, endOffset)];
+    return [decoder(buffer, startOffset, endOffset)];
   }
-  return stringValue(buffer, startOffset, endOffset);
+  return decoder(buffer, startOffset, endOffset);
 };
 
 const decodeNistFieldValue = (
@@ -159,7 +163,9 @@ const decodeNistFieldValue = (
   buffer: Buffer,
   startOffset: number,
   endOffset: number,
+  options?: NistFieldDecodeOptions,
 ): NistFieldValue => {
+  const decoder = options?.informationDecoder || stringValue;
   let offset = startOffset;
 
   let recordSeparator = findSeparator(buffer, SEPARATOR_RECORD, offset, endOffset);
@@ -170,9 +176,9 @@ const decodeNistFieldValue = (
     if (!unitSeparator) {
       // The same logic is present also in decodeNistSubfield.
       if (alwaysDecodeAsSet(key)) {
-        return [[stringValue(buffer, startOffset, endOffset)]];
+        return [[decoder(buffer, startOffset, endOffset)]];
       }
-      return stringValue(buffer, startOffset, endOffset);
+      return decoder(buffer, startOffset, endOffset);
     }
     // Also deal with the case there is no record separator but some unit separators.
     return [decodeNistSubfield(key, buffer, startOffset, endOffset)];
@@ -343,6 +349,7 @@ export const decodeGenericNistRecord = (
   recordInstance: number,
   startOffset: number,
   endOffset: number,
+  options?: NistRecordDecodeOptions,
 ): Result<DecodeGenericRecordResult, NistDecodeError> => {
   let offset = startOffset;
   let recordEndOffset: number | null = null; // This will be assigned after parsing LEN field.
@@ -388,7 +395,13 @@ export const decodeGenericNistRecord = (
     const value =
       nistFieldKey.value.key.field === 999
         ? buffer.subarray(valueStartOffset, fieldEndOffset)
-        : decodeNistFieldValue(nistFieldKey.value.key, buffer, valueStartOffset, fieldEndOffset);
+        : decodeNistFieldValue(
+            nistFieldKey.value.key,
+            buffer,
+            valueStartOffset,
+            fieldEndOffset,
+            options,
+          );
     const nistField = { key: nistFieldKey.value.key, value };
 
     if (nistField.key.field === 1) {
@@ -445,7 +458,10 @@ const addRecord = (
   }
 };
 
-const decodeNistFile = (buffer: Buffer): Result<NistFileInternal, NistDecodeError> => {
+const decodeNistFile = (
+  buffer: Buffer,
+  options: NistDecodeOptions,
+): Result<NistFileInternal, NistDecodeError> => {
   let offset = 0;
   const endOffset = buffer.length - 1;
 
@@ -476,6 +492,9 @@ const decodeNistFile = (buffer: Buffer): Result<NistFileInternal, NistDecodeErro
 
   const nistFile: NistFileInternal = { 1: type1Record };
   offset = separatorOffset + 1;
+
+  const perTotOptions =
+    options?.codecOptions && getPerTotOptions(options.codecOptions, type1Record[4]);
 
   // 2. Decode all the remaining records in the order given by 1.003 (CNT).
   for (let recordIndex = 1; recordIndex < type1Record[3].length; recordIndex += 1) {
@@ -556,6 +575,7 @@ const decodeNistFile = (buffer: Buffer): Result<NistFileInternal, NistDecodeErro
           : (nistFile[recordTypeNumber] as NistRecord[]).length,
         offset,
         endOffset,
+        perTotOptions && perTotOptions[recordTypeNumber],
       );
       if (decodeResult.tag === 'failure') {
         return decodeResult;
@@ -576,7 +596,7 @@ export const nistDecode = (
   options: NistDecodeOptions = {},
 ): Result<NistFile, NistDecodeError | NistValidationError> => {
   // 1. Decode the buffer.
-  const nistFileInternal = decodeNistFile(buffer);
+  const nistFileInternal = decodeNistFile(buffer, options);
   if (nistFileInternal.tag === 'failure') {
     return nistFileInternal;
   }

--- a/src/nistEncode.test.ts
+++ b/src/nistEncode.test.ts
@@ -596,6 +596,44 @@ describe('positive test:', () => {
     expect((result as Success<Buffer>).value.byteLength).toBe(880293);
     expect((result as Success<Buffer>).value).toMatchSnapshot();
   });
+
+  it('Type-1, Type-2 with alternative informationWriter', () => {
+    const nist: NistFile = {
+      1: {
+        2: '0502',
+        4: 'CRM',
+        5: '20191201',
+        7: 'DAI035454',
+        8: 'ORI38574354',
+        9: 'TCN2487S054',
+      },
+      2: {
+        4: 'John',
+        5: 'Doe',
+        7: '1978-05-12',
+      },
+    };
+
+    const result = nistEncode(nist, {
+      ...nistEncodeOptions,
+      codecOptions: {
+        ...nistEncodeOptions.codecOptions,
+        default: {
+          2: {
+            5: {
+              informationWriter: (information) => {
+                if (typeof information == 'string') return Buffer.from(information, 'latin1');
+                return information;
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(result.tag).toEqual('success');
+    expect((result as Success<Buffer>).value.byteLength).toBe(169);
+    expect((result as Success<Buffer>).value).toMatchSnapshot();
+  });
 });
 
 describe('negative test:', () => {

--- a/src/nistEncode.ts
+++ b/src/nistEncode.ts
@@ -80,9 +80,7 @@ const invokeFormatters = ({
   return success(undefined);
 };
 
-const defaultInformationWriter = (
-  informationItem: string,
-): Buffer => {
+const defaultInformationWriter = (informationItem: string): Buffer => {
   return Buffer.from(informationItem);
 };
 

--- a/src/nistEncode.ts
+++ b/src/nistEncode.ts
@@ -81,12 +81,9 @@ const invokeFormatters = ({
 };
 
 const defaultInformationWriter = (
-  informationItem: Exclude<NistInformationItem, undefined>,
+  informationItem: string,
 ): Buffer => {
-  if (typeof informationItem === 'string') {
-    return Buffer.from(informationItem);
-  }
-  return informationItem;
+  return Buffer.from(informationItem);
 };
 
 /* --------------------------- Automatic fields ------------------------------------------------- */

--- a/src/nistVisitor.ts
+++ b/src/nistVisitor.ts
@@ -216,6 +216,15 @@ interface VisitNistFileParams<
   recordVisitor?: NistRecordVisitor<D, T>;
   fieldVisitor?: NistFieldVisitor<D, T>;
 }
+
+export const getPerTotOptions = <
+  T extends NistFieldCodecOptions,
+  U extends NistRecordCodecOptions<T>,
+>(
+  options: NistFileCodecOptions<T, U>,
+  tot: string,
+) => R.mergeDeepRight(options.default, options[tot] || {});
+
 /* Visits the whole NistFile, all types, all records, all fields.
    recordVisitor and fieldVisitor can be overriden. */
 export const visitNistFile = <
@@ -232,7 +241,7 @@ export const visitNistFile = <
   const nistFile = nist as unknown as NistFileInternal;
   let summaryResult: Result<void, NistValidationError> = success(undefined); // assume success
 
-  const perTotOptions = options && R.mergeDeepRight(options.default, options[nist[1][4]] || {});
+  const perTotOptions = options && getPerTotOptions(options, nist[1][4]);
 
   for (const recordTypeNumber of nistRecordTypeNumbers) {
     if (nistFile[recordTypeNumber]) {

--- a/src/nistVisitor.ts
+++ b/src/nistVisitor.ts
@@ -8,6 +8,7 @@ import {
   NistFieldValue,
   NistFile,
   NistFileCodecOptions,
+  NistFileCodecOptionsPerTot,
   NistRecord,
   NistRecordCodecOptions,
 } from './index';
@@ -223,7 +224,7 @@ export const getPerTotOptions = <
 >(
   options: NistFileCodecOptions<T, U>,
   tot: string,
-) => R.mergeDeepRight(options.default, options[tot] || {});
+): NistFileCodecOptionsPerTot<T, U> => R.mergeDeepRight(options.default, options[tot] || {});
 
 /* Visits the whole NistFile, all types, all records, all fields.
    recordVisitor and fieldVisitor can be overriden. */


### PR DESCRIPTION
## Changes

- Added the option to pass an alternative encoder (`informationWriter`) to each Field for `nistEncode`. 
- Added the option to pass an alternative decoder (`informationDecoder`) to each Field for `nistDecode`.